### PR TITLE
ci: Add code coverage check

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = true
+omit =
+    */__init__.py
+
+[report]
+show_missing = true
+fail_under = 89

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,4 @@ omit =
 
 [report]
 show_missing = true
-fail_under = 89
+fail_under = 90

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,4 @@ omit =
 
 [report]
 show_missing = true
-fail_under = 90
+fail_under = 81

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -58,7 +58,7 @@ substitutions:
   _VERSION: "3.8"
 ```
 
-Use `gcloud builds triggers import --source=trigger.yaml` create triggers via the command line
+Use `gcloud builds triggers import --source=trigger.yaml` to create triggers via the command line
 
 #### Project Setup
 
@@ -76,6 +76,18 @@ Use `gcloud builds triggers import --source=trigger.yaml` create triggers via th
 #### Trigger
 
 To run Cloud Build tests on GitHub from external contributors, ie RenovateBot, comment: `/gcbrun`.
+
+#### Code Coverage
+Please make sure your code is fully tested. The Cloud Build integration tests are run with the `pytest-cov` code coverage plugin. They fail for PRs with a code coverage less than the threshold specified in `.coveragerc`.  If your file is inside the main module and should be ignored by code coverage check, add it to the `omit` section of `.coveragerc`.
+
+Check for code coverage report in any Cloud Build integration test log. 
+Here is a breakdown of the report:
+- `Stmts`:  lines of executable code (statements).
+- `Miss`: number of lines not covered by tests.
+- `Branch`: branches of executable code (e.g an if-else clause may count as 1 statement but 2 branches; test for both conditions to have both branches covered).
+- `BrPart`: number of branches not covered by tests.
+- `Cover`: average coverage of files.
+- `Missing`: lines that are not covered by tests.
 
 
 [triggers]: https://console.cloud.google.com/cloud-build/triggers?e=13802955&project=langchain-spanner-testing

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   - id: Run integration tests
     name: python:${_VERSION}
     entrypoint: python
-    args: ["-m", "pytest"]
+    args: ["-m", "pytest", "--cov=langchain_google_spanner", "--cov-config=.coveragerc", "tests/"]
     env:
       - "PROJECT_ID=$PROJECT_ID"
       - "INSTANCE_ID=${_INSTANCE_ID}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "mypy==1.10.0",
     "pytest==7.4.4",
     "pytest-asyncio==0.23.6",
+    "pytest-cov==5.0.0"
 ]
 
 [build-system]


### PR DESCRIPTION
Add code coverage check as part of running test suite. Test suite will fail with coverage below the current level (target 90%).