### PR TITLE
refactor: Use named arguments instead of positional

### DIFF
--- a/src/langchain_google_spanner/vector_store.py
+++ b/src/langchain_google_spanner/vector_store.py
@@ -830,7 +830,9 @@ class SpannerVectorStore(VectorStore):
         """
 
         results, column_order_map = self._get_rows_by_similarity_search(
-            embedding, k, pre_filter
+            embedding=embedding,
+            k=k,
+            pre_filter=pre_filter
         )
         documents = self._get_documents_from_query_results(
             list(results), column_order_map


### PR DESCRIPTION
Fixed a bug where using both k and pre_filter search_kwargs caused in valid SQL generation.

The broken SQL had ```LIMIT <whatever_field>``` generated instead of using k. Moving away from position args fixed things.