### PR TITLE
fix: Validate the embeddings size to catch silent embeddings batch failures

### DIFF
--- a/src/langchain_google_spanner/vector_store.py
+++ b/src/langchain_google_spanner/vector_store.py
@@ -672,6 +672,13 @@ class SpannerVectorStore(VectorStore):
 
         embeds = self._embedding_service.embed_documents(texts_list)
 
+        if len(embeds) != number_of_records:
+            raise ValueError(
+                "Number of embeddings should equal the number of documents."
+                "Try reducing the batch size when adding the documents."
+                f" Expected: {number_of_records}, but found {len(embeds)}"
+            )
+
         if metadatas is None:
             metadatas = [{} for _ in texts]
 


### PR DESCRIPTION
With a larger batch size for `add_documents` (e.g. 1000), the embeddings service may silently fail and return nothing for some entries. This lead to the more cryptic error:
```
[values_dict[key][i] for key in values_dict]
     ~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
Add additional size validation and a suggestion on how to remedy.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/langchain-google-spanner-python/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
