### PR TITLE
feat(graph): Flexible Schema Extension to SpannerGraphStore

### DIFF
--- a/docs/graph_store.ipynb
+++ b/docs/graph_store.ipynb
@@ -1,28 +1,10 @@
 {
- "nbformat": 4,
- "nbformat_minor": 4,
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.5"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "7VBkjcqNNxEd"
+   },
    "source": [
     "# Google Spanner\n",
     "\n",
@@ -33,13 +15,13 @@
     "Learn more about the package on [GitHub](https://github.com/googleapis/langchain-google-spanner-python/).\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/googleapis/langchain-google-spanner-python/blob/main/docs/graph_store.ipynb)"
-   ],
-   "metadata": {
-    "id": "7VBkjcqNNxEd"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "HEAGYTPgNydh"
+   },
    "source": [
     "## Before You Begin\n",
     "\n",
@@ -49,96 +31,104 @@
     " * [Enable the Cloud Spanner API](https://console.cloud.google.com/flows/enableapi?apiid=spanner.googleapis.com)\n",
     " * [Create a Spanner instance](https://cloud.google.com/spanner/docs/create-manage-instances)\n",
     " * [Create a Spanner database](https://cloud.google.com/spanner/docs/create-manage-databases)"
-   ],
-   "metadata": {
-    "id": "HEAGYTPgNydh"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "cboPIg-yOcxS"
+   },
    "source": [
     "### 🦜🔗 Library Installation\n",
     "The integration lives in its own `langchain-google-spanner` package, so we need to install it."
-   ],
-   "metadata": {
-    "id": "cboPIg-yOcxS"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "%pip install --upgrade --quiet langchain-google-spanner langchain-google-vertexai langchain-experimental json-repair wikipedia pyvis youtube-transcript-api"
-   ],
+   "execution_count": 38,
    "metadata": {
     "id": "AOWh6QKYVdDp"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --upgrade --quiet langchain-google-spanner langchain-google-vertexai langchain-experimental json-repair wikipedia pyvis youtube-transcript-api"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
-   ],
    "metadata": {
     "id": "M7MqpDhkOiP-"
-   }
+   },
+   "source": [
+    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xzgVZv0POj17",
+    "outputId": "066ba1ae-c89e-427e-8a98-7f76f90155d0"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'status': 'ok', 'restart': True}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
     "import IPython\n",
     "\n",
     "app = IPython.Application.instance()\n",
     "app.kernel.do_shutdown(True)"
-   ],
-   "metadata": {
-    "id": "xzgVZv0POj17",
-    "outputId": "066ba1ae-c89e-427e-8a98-7f76f90155d0"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "{'status': 'ok', 'restart': True}"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 3
-    }
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "zfIhwIryOls1"
+   },
    "source": [
     "### 🔐 Authentication\n",
     "Authenticate to Google Cloud as the IAM user logged into this notebook in order to access your Google Cloud Project.\n",
     "\n",
     "* If you are using Colab to run this notebook, use the cell below and continue.\n",
     "* If you are using Vertex AI Workbench, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
-   ],
-   "metadata": {
-    "id": "zfIhwIryOls1"
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EWOkHI7XOna2"
+   },
+   "outputs": [],
    "source": [
     "from google.colab import auth\n",
     "\n",
     "auth.authenticate_user()"
-   ],
-   "metadata": {
-    "id": "EWOkHI7XOna2"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "6xHXneICOpsB"
+   },
    "source": [
     "### ☁ Set Your Google Cloud Project\n",
     "Set your Google Cloud project so that you can leverage Google Cloud resources within this notebook.\n",
@@ -148,13 +138,15 @@
     "* Run `gcloud config list`.\n",
     "* Run `gcloud projects list`.\n",
     "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)."
-   ],
-   "metadata": {
-    "id": "6xHXneICOpsB"
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hF0481BGOsS8"
+   },
+   "outputs": [],
    "source": [
     "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
     "\n",
@@ -163,112 +155,70 @@
     "# Set the project id\n",
     "!gcloud config set project {PROJECT_ID}\n",
     "%env GOOGLE_CLOUD_PROJECT={PROJECT_ID}"
-   ],
-   "metadata": {
-    "id": "hF0481BGOsS8"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "4TiC0RbhOwUu"
+   },
    "source": [
     "### 💡 API Enablement\n",
     "The `langchain-google-spanner` package requires that you [enable the Spanner API](https://console.cloud.google.com/flows/enableapi?apiid=spanner.googleapis.com) in your Google Cloud Project."
-   ],
-   "metadata": {
-    "id": "4TiC0RbhOwUu"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "# enable Spanner API\n",
-    "!gcloud services enable spanner.googleapis.com"
-   ],
+   "execution_count": null,
    "metadata": {
     "id": "9f3fJd5eOyRr"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "# enable Spanner API\n",
+    "!gcloud services enable spanner.googleapis.com"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Basic Usage"
-   ],
    "metadata": {
     "id": "k5pxMMiMOzt7"
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "### Set Spanner database values\n",
-    "Find your database values, in the [Spanner Instances page](https://console.cloud.google.com/spanner?_ga=2.223735448.2062268965.1707700487-2088871159.1707257687)."
-   ],
-   "metadata": {
-    "id": "mtDbLU5sO2iA"
-   }
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "# @title Set Your Values Here { display-mode: \"form\" }\n",
-    "INSTANCE = \"\"  # @param {type: \"string\"}\n",
-    "DATABASE = \"\"  # @param {type: \"string\"}\n",
-    "GRAPH_NAME = \"\"  # @param {type: \"string\"}"
-   ],
-   "metadata": {
-    "id": "C-I8VTIcO442"
    },
-   "execution_count": null,
-   "outputs": []
+   "source": [
+    "## Basic Usage"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### SpannerGraphStore\n",
-    "\n",
-    "To initialize the `SpannerGraphStore` class you need to provide 3 required arguments and other arguments are optional and only need to pass if it's different from default ones\n",
-    "\n",
-    "1.   a Spanner instance id;\n",
-    "2.   a Spanner database id belongs to the above instance id;\n",
-    "3.   a Spanner graph name used to create a graph in the above database."
-   ],
-   "metadata": {
-    "id": "kpAv-tpcO_iL"
-   }
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from langchain_google_spanner import SpannerGraphStore\n",
-    "\n",
-    "graph_store = SpannerGraphStore(\n",
-    "    instance_id=INSTANCE,\n",
-    "    database_id=DATABASE,\n",
-    "    graph_name=GRAPH_NAME,\n",
-    ")"
-   ],
-   "metadata": {
-    "id": "u589YapWQFb8"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "#### Add Graph Documents\n",
-    "To add graph documents in the graph store."
-   ],
    "metadata": {
     "id": "G7-Pe2ADQlNJ"
-   }
+   },
+   "source": [
+    "### Prepare graph documents\n",
+    "\n",
+    "Prepare graph documents from various sources to be added to Spanner Graph."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "0rdoT01aRiNI",
+    "outputId": "c63f6325-3e64-481e-e3d8-a3cb73be2d95"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fetching document from Wikipedia: `Google`\n",
+      "Fetching document from YouTube: `https://www.youtube.com/watch?v=WsEQjeZoEng`\n"
+     ]
+    }
+   ],
    "source": [
     "# @title Get graph documents from Wikipedia & YouTube\n",
     "from langchain_community.document_loaders import WikipediaLoader, YoutubeLoader\n",
@@ -298,35 +248,11 @@
     "graph_documents = llm_transformer.convert_to_graph_documents(\n",
     "    [document for documents in document_batch for document in documents]\n",
     ")"
-   ],
-   "metadata": {
-    "id": "0rdoT01aRiNI",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "c63f6325-3e64-481e-e3d8-a3cb73be2d95"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Fetching document from Wikipedia: `Google`\n",
-      "Fetching document from YouTube: `https://www.youtube.com/watch?v=WsEQjeZoEng`\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "for doc in graph_documents:\n",
-    "    print(doc.source.page_content[:100])\n",
-    "    print(doc.nodes)\n",
-    "    print(doc.relationships)\n",
-    "    print()"
-   ],
+   "execution_count": 53,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -334,13 +260,12 @@
     "id": "OylyNyv-ZsT2",
     "outputId": "875bf1c3-62e5-4a0b-d064-1900ecc8d405"
    },
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Google LLC (  GOO-ghəl) is an American multinational corporation and technology company focusing on \n",
+      "Google LLC ( , GOO-gəl) is an American multinational corporation and technology company focusing on \n",
       "[Node(id='Google LLC', type='Company', properties={}), Node(id='Larry Page', type='Person', properties={}), Node(id='Sergey Brin', type='Person', properties={})]\n",
       "[Relationship(source=Node(id='Google LLC', type='Company', properties={}), target=Node(id='Larry Page', type='Person', properties={}), type='FOUNDED_BY', properties={}), Relationship(source=Node(id='Google LLC', type='Company', properties={}), target=Node(id='Sergey Brin', type='Person', properties={}), type='FOUNDED_BY', properties={})]\n",
       "\n",
@@ -351,16 +276,91 @@
       "\n"
      ]
     }
+   ],
+   "source": [
+    "for doc in graph_documents:\n",
+    "    print(doc.source.page_content[:100])\n",
+    "    print(doc.nodes)\n",
+    "    print(doc.relationships)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mtDbLU5sO2iA"
+   },
+   "source": [
+    "### Set Spanner database values\n",
+    "Find your database values, in the [Spanner Instances page](https://console.cloud.google.com/spanner?_ga=2.223735448.2062268965.1707700487-2088871159.1707257687).\n",
+    "\n",
+    "NOTE:\n",
+    "- The database identified by INSTANCE and DATABASE must be created beforehand.\n",
+    "- The graph does NOT need to be created beforehand.\n",
+    "  \n",
+    "  If such a graph already exists, graphs will be built atop; otherwise a new graph is automatically created."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {
+    "id": "C-I8VTIcO442"
+   },
+   "outputs": [],
    "source": [
-    "graph_store.cleanup()\n",
+    "# @title Set Your Values Here { display-mode: \"form\" }\n",
+    "INSTANCE = \"\"  # @param {type: \"string\"}\n",
+    "DATABASE = \"\"  # @param {type: \"string\"}\n",
+    "GRAPH_NAME = \"\"  # @param {type: \"string\"}\n",
+    "USE_FLEXIBLE_SCHEMA = False  # param {type: \"bool\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kpAv-tpcO_iL"
+   },
+   "source": [
+    "### SpannerGraphStore\n",
     "\n",
-    "for graph_document in graph_documents:\n",
-    "    graph_store.add_graph_documents([graph_document])"
-   ],
+    "To initialize the `SpannerGraphStore` class you need to provide 3 required arguments and other arguments are optional and only need to pass if it's different from default ones\n",
+    "\n",
+    "1.   a Spanner instance id;\n",
+    "2.   a Spanner database id belongs to the above instance id;\n",
+    "3.   a Spanner graph name used to create a graph in the above database.\n",
+    "\n",
+    "#### SpannerGraphStore with flexible schema\n",
+    "\n",
+    "By default, SpannerGraphStore creates an underlying table for each type of nodes and edges.\n",
+    "This will create many underlying tables when your graph consists of many different types of nodes and edges.\n",
+    "\n",
+    "SpannerGraphStore provides a flexible schema mode that stores all your nodes in a single node table and edges in a single edge table.\n",
+    "\n",
+    "To use it, set USE_FLEXIBLE_SCHEMA to True."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {
+    "id": "u589YapWQFb8"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_spanner import SpannerGraphStore\n",
+    "\n",
+    "graph_store = SpannerGraphStore(\n",
+    "    instance_id=INSTANCE,\n",
+    "    database_id=DATABASE,\n",
+    "    graph_name=GRAPH_NAME,\n",
+    "    use_flexible_schema=USE_FLEXIBLE_SCHEMA,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -368,89 +368,100 @@
     "id": "lMXvOpRbZdau",
     "outputId": "3c6ca58c-0e6a-4b7f-a204-eab08adb2761"
    },
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
+      "Clean up existing data...\n",
       "Waiting for DDL operations to complete...\n",
       "Waiting for DDL operations to complete...\n",
       "Waiting for DDL operations to complete...\n",
+      "Add new data...\n",
       "Waiting for DDL operations to complete...\n",
       "Insert nodes of type `Company`...\n",
-      "Executed DML statement: 1 rows updated\n",
       "Insert nodes of type `Person`...\n",
-      "Executed DML statement: 2 rows updated\n",
-      "Insert edges of type `FOUNDED_BY`...\n",
-      "Executed DML statement: 2 rows updated\n",
-      "Waiting for DDL operations to complete...\n",
+      "Insert edges of type `Company_FOUNDED_BY_Person`...\n",
+      "No schema change required...\n",
       "Insert nodes of type `Company`...\n",
-      "Executed DML statement: 1 rows updated\n",
       "Insert nodes of type `Product`...\n",
-      "Executed DML statement: 1 rows updated\n",
       "Insert nodes of type `Feature`...\n",
-      "Executed DML statement: 1 rows updated\n",
-      "Insert edges of type `HAS_PRODUCT`...\n",
-      "Executed DML statement: 1 rows updated\n",
-      "Insert edges of type `HAS_FEATURE`...\n",
-      "Executed DML statement: 1 rows updated\n"
+      "Insert edges of type `Company_HAS_PRODUCT_Product`...\n",
+      "Insert edges of type `Product_HAS_FEATURE_Feature`...\n"
      ]
     }
+   ],
+   "source": [
+    "print(\"Clean up existing data...\")\n",
+    "graph_store.cleanup()\n",
+    "\n",
+    "print(\"Add new data...\")\n",
+    "for graph_document in graph_documents:\n",
+    "    graph_store.add_graph_documents([graph_document])"
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "v5b572QbSi4t"
+   },
    "source": [
     "#### Query the graph\n",
     "To traverse the graph in the graph store."
-   ],
-   "metadata": {
-    "id": "v5b572QbSi4t"
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9YpR4cauSsfG",
+    "outputId": "387bb32b-c28b-4be7-efe8-7797c5914d1c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'google_related_nodes': ['Larry Page', 'Gemini', 'Google', 'summarize emails', 'Sergey Brin', 'Google LLC']}]\n"
+     ]
+    }
+   ],
    "source": [
     "sample_query = \"\"\"\n",
     "  GRAPH {}\n",
-    "  MATCH (n:Company WHERE REGEXP_CONTAINS(n.id, 'Google')) -[e]-{{1, 2}} (m)\n",
+    "  MATCH (n WHERE REGEXP_CONTAINS(n.id, 'Google')) -[e]-{{1, 2}} (m)\n",
     "  RETURN ARRAY_AGG(DISTINCT m.id) AS google_related_nodes\n",
     "\"\"\".format(\n",
     "    GRAPH_NAME\n",
     ")\n",
     "\n",
     "print(graph_store.query(sample_query))"
-   ],
-   "metadata": {
-    "id": "9YpR4cauSsfG",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "387bb32b-c28b-4be7-efe8-7797c5914d1c"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[{'google_related_nodes': ['Larry Page', 'Gemini', 'Google', 'summarize emails', 'Sergey Brin', 'Google LLC']}]\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Visualize the graph"
-   ],
    "metadata": {
     "id": "Xau7BXvb_6si"
-   }
+   },
+   "source": [
+    "#### Visualize the graph"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 551
+    },
+    "id": "pQuQzOng_9GK",
+    "outputId": "2d791b28-f51a-4c20-de3b-6293fd84070d"
+   },
+   "outputs": [],
    "source": [
     "from pyvis.network import Network\n",
     "from IPython.core.display import display, HTML\n",
@@ -491,423 +502,73 @@
     "net.toggle_physics(True)\n",
     "net.show(\"graph.html\")\n",
     "display(HTML(\"graph.html\"))"
-   ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 551
-    },
-    "id": "pQuQzOng_9GK",
-    "outputId": "2d791b28-f51a-4c20-de3b-6293fd84070d"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "graph.html\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ],
-      "text/html": [
-       "<html>\n",
-       "    <head>\n",
-       "        <meta charset=\"utf-8\">\n",
-       "        \n",
-       "            <script>function neighbourhoodHighlight(params) {\n",
-       "  // console.log(\"in nieghbourhoodhighlight\");\n",
-       "  allNodes = nodes.get({ returnType: \"Object\" });\n",
-       "  // originalNodes = JSON.parse(JSON.stringify(allNodes));\n",
-       "  // if something is selected:\n",
-       "  if (params.nodes.length > 0) {\n",
-       "    highlightActive = true;\n",
-       "    var i, j;\n",
-       "    var selectedNode = params.nodes[0];\n",
-       "    var degrees = 2;\n",
-       "\n",
-       "    // mark all nodes as hard to read.\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      // nodeColors[nodeId] = allNodes[nodeId].color;\n",
-       "      allNodes[nodeId].color = \"rgba(200,200,200,0.5)\";\n",
-       "      if (allNodes[nodeId].hiddenLabel === undefined) {\n",
-       "        allNodes[nodeId].hiddenLabel = allNodes[nodeId].label;\n",
-       "        allNodes[nodeId].label = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "    var connectedNodes = network.getConnectedNodes(selectedNode);\n",
-       "    var allConnectedNodes = [];\n",
-       "\n",
-       "    // get the second degree nodes\n",
-       "    for (i = 1; i < degrees; i++) {\n",
-       "      for (j = 0; j < connectedNodes.length; j++) {\n",
-       "        allConnectedNodes = allConnectedNodes.concat(\n",
-       "          network.getConnectedNodes(connectedNodes[j])\n",
-       "        );\n",
-       "      }\n",
-       "    }\n",
-       "\n",
-       "    // all second degree nodes get a different color and their label back\n",
-       "    for (i = 0; i < allConnectedNodes.length; i++) {\n",
-       "      // allNodes[allConnectedNodes[i]].color = \"pink\";\n",
-       "      allNodes[allConnectedNodes[i]].color = \"rgba(150,150,150,0.75)\";\n",
-       "      if (allNodes[allConnectedNodes[i]].hiddenLabel !== undefined) {\n",
-       "        allNodes[allConnectedNodes[i]].label =\n",
-       "          allNodes[allConnectedNodes[i]].hiddenLabel;\n",
-       "        allNodes[allConnectedNodes[i]].hiddenLabel = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "\n",
-       "    // all first degree nodes get their own color and their label back\n",
-       "    for (i = 0; i < connectedNodes.length; i++) {\n",
-       "      // allNodes[connectedNodes[i]].color = undefined;\n",
-       "      allNodes[connectedNodes[i]].color = nodeColors[connectedNodes[i]];\n",
-       "      if (allNodes[connectedNodes[i]].hiddenLabel !== undefined) {\n",
-       "        allNodes[connectedNodes[i]].label =\n",
-       "          allNodes[connectedNodes[i]].hiddenLabel;\n",
-       "        allNodes[connectedNodes[i]].hiddenLabel = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "\n",
-       "    // the main node gets its own color and its label back.\n",
-       "    // allNodes[selectedNode].color = undefined;\n",
-       "    allNodes[selectedNode].color = nodeColors[selectedNode];\n",
-       "    if (allNodes[selectedNode].hiddenLabel !== undefined) {\n",
-       "      allNodes[selectedNode].label = allNodes[selectedNode].hiddenLabel;\n",
-       "      allNodes[selectedNode].hiddenLabel = undefined;\n",
-       "    }\n",
-       "  } else if (highlightActive === true) {\n",
-       "    // console.log(\"highlightActive was true\");\n",
-       "    // reset all nodes\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      // allNodes[nodeId].color = \"purple\";\n",
-       "      allNodes[nodeId].color = nodeColors[nodeId];\n",
-       "      // delete allNodes[nodeId].color;\n",
-       "      if (allNodes[nodeId].hiddenLabel !== undefined) {\n",
-       "        allNodes[nodeId].label = allNodes[nodeId].hiddenLabel;\n",
-       "        allNodes[nodeId].hiddenLabel = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "    highlightActive = false;\n",
-       "  }\n",
-       "\n",
-       "  // transform the object into an array\n",
-       "  var updateArray = [];\n",
-       "  if (params.nodes.length > 0) {\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      if (allNodes.hasOwnProperty(nodeId)) {\n",
-       "        // console.log(allNodes[nodeId]);\n",
-       "        updateArray.push(allNodes[nodeId]);\n",
-       "      }\n",
-       "    }\n",
-       "    nodes.update(updateArray);\n",
-       "  } else {\n",
-       "    // console.log(\"Nothing was selected\");\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      if (allNodes.hasOwnProperty(nodeId)) {\n",
-       "        // console.log(allNodes[nodeId]);\n",
-       "        // allNodes[nodeId].color = {};\n",
-       "        updateArray.push(allNodes[nodeId]);\n",
-       "      }\n",
-       "    }\n",
-       "    nodes.update(updateArray);\n",
-       "  }\n",
-       "}\n",
-       "\n",
-       "function filterHighlight(params) {\n",
-       "  allNodes = nodes.get({ returnType: \"Object\" });\n",
-       "  // if something is selected:\n",
-       "  if (params.nodes.length > 0) {\n",
-       "    filterActive = true;\n",
-       "    let selectedNodes = params.nodes;\n",
-       "\n",
-       "    // hiding all nodes and saving the label\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      allNodes[nodeId].hidden = true;\n",
-       "      if (allNodes[nodeId].savedLabel === undefined) {\n",
-       "        allNodes[nodeId].savedLabel = allNodes[nodeId].label;\n",
-       "        allNodes[nodeId].label = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "\n",
-       "    for (let i=0; i < selectedNodes.length; i++) {\n",
-       "      allNodes[selectedNodes[i]].hidden = false;\n",
-       "      if (allNodes[selectedNodes[i]].savedLabel !== undefined) {\n",
-       "        allNodes[selectedNodes[i]].label = allNodes[selectedNodes[i]].savedLabel;\n",
-       "        allNodes[selectedNodes[i]].savedLabel = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "\n",
-       "  } else if (filterActive === true) {\n",
-       "    // reset all nodes\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      allNodes[nodeId].hidden = false;\n",
-       "      if (allNodes[nodeId].savedLabel !== undefined) {\n",
-       "        allNodes[nodeId].label = allNodes[nodeId].savedLabel;\n",
-       "        allNodes[nodeId].savedLabel = undefined;\n",
-       "      }\n",
-       "    }\n",
-       "    filterActive = false;\n",
-       "  }\n",
-       "\n",
-       "  // transform the object into an array\n",
-       "  var updateArray = [];\n",
-       "  if (params.nodes.length > 0) {\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      if (allNodes.hasOwnProperty(nodeId)) {\n",
-       "        updateArray.push(allNodes[nodeId]);\n",
-       "      }\n",
-       "    }\n",
-       "    nodes.update(updateArray);\n",
-       "  } else {\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      if (allNodes.hasOwnProperty(nodeId)) {\n",
-       "        updateArray.push(allNodes[nodeId]);\n",
-       "      }\n",
-       "    }\n",
-       "    nodes.update(updateArray);\n",
-       "  }\n",
-       "}\n",
-       "\n",
-       "function selectNode(nodes) {\n",
-       "  network.selectNodes(nodes);\n",
-       "  neighbourhoodHighlight({ nodes: nodes });\n",
-       "  return nodes;\n",
-       "}\n",
-       "\n",
-       "function selectNodes(nodes) {\n",
-       "  network.selectNodes(nodes);\n",
-       "  filterHighlight({nodes: nodes});\n",
-       "  return nodes;\n",
-       "}\n",
-       "\n",
-       "function highlightFilter(filter) {\n",
-       "  let selectedNodes = []\n",
-       "  let selectedProp = filter['property']\n",
-       "  if (filter['item'] === 'node') {\n",
-       "    let allNodes = nodes.get({ returnType: \"Object\" });\n",
-       "    for (let nodeId in allNodes) {\n",
-       "      if (allNodes[nodeId][selectedProp] && filter['value'].includes((allNodes[nodeId][selectedProp]).toString())) {\n",
-       "        selectedNodes.push(nodeId)\n",
-       "      }\n",
-       "    }\n",
-       "  }\n",
-       "  else if (filter['item'] === 'edge'){\n",
-       "    let allEdges = edges.get({returnType: 'object'});\n",
-       "    // check if the selected property exists for selected edge and select the nodes connected to the edge\n",
-       "    for (let edge in allEdges) {\n",
-       "      if (allEdges[edge][selectedProp] && filter['value'].includes((allEdges[edge][selectedProp]).toString())) {\n",
-       "        selectedNodes.push(allEdges[edge]['from'])\n",
-       "        selectedNodes.push(allEdges[edge]['to'])\n",
-       "      }\n",
-       "    }\n",
-       "  }\n",
-       "  selectNodes(selectedNodes)\n",
-       "}</script>\n",
-       "            <link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/vis-network/9.1.2/dist/dist/vis-network.min.css\" integrity=\"sha512-WgxfT5LWjfszlPHXRmBWHkV2eceiWTOBvrKCNbdgDYTHrT2AeLCGbF4sZlZw3UMN3WtL0tGUoIAKsu8mllg/XA==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />\n",
-       "            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/vis-network/9.1.2/dist/vis-network.min.js\" integrity=\"sha512-LnvoEWDFrqGHlHmDD2101OrLcbsfkrzoSpvtSQtxK3RMnRV0eOkhhBN2dXHKRrUU8p2DGRTk35n4O8nWSVe1mQ==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>\n",
-       "            \n",
-       "            \n",
-       "            \n",
-       "            \n",
-       "            \n",
-       "            \n",
-       "\n",
-       "        \n",
-       "<center>\n",
-       "<h1></h1>\n",
-       "</center>\n",
-       "\n",
-       "<!-- <link rel=\"stylesheet\" href=\"../node_modules/vis/dist/vis.min.css\" type=\"text/css\" />\n",
-       "<script type=\"text/javascript\" src=\"../node_modules/vis/dist/vis.js\"> </script>-->\n",
-       "        <link\n",
-       "          href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css\"\n",
-       "          rel=\"stylesheet\"\n",
-       "          integrity=\"sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6\"\n",
-       "          crossorigin=\"anonymous\"\n",
-       "        />\n",
-       "        <script\n",
-       "          src=\"https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js\"\n",
-       "          integrity=\"sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf\"\n",
-       "          crossorigin=\"anonymous\"\n",
-       "        ></script>\n",
-       "\n",
-       "\n",
-       "        <center>\n",
-       "          <h1></h1>\n",
-       "        </center>\n",
-       "        <style type=\"text/css\">\n",
-       "\n",
-       "             #mynetwork {\n",
-       "                 width: 50%;\n",
-       "                 height: 500px;\n",
-       "                 background-color: #222222;\n",
-       "                 border: 1px solid lightgray;\n",
-       "                 position: relative;\n",
-       "                 float: left;\n",
-       "             }\n",
-       "\n",
-       "             \n",
-       "\n",
-       "             \n",
-       "\n",
-       "             \n",
-       "        </style>\n",
-       "    </head>\n",
-       "\n",
-       "\n",
-       "    <body>\n",
-       "        <div class=\"card\" style=\"width: 100%\">\n",
-       "            \n",
-       "            \n",
-       "            <div id=\"mynetwork\" class=\"card-body\"></div>\n",
-       "        </div>\n",
-       "\n",
-       "        \n",
-       "        \n",
-       "\n",
-       "        <script type=\"text/javascript\">\n",
-       "\n",
-       "              // initialize global variables.\n",
-       "              var edges;\n",
-       "              var nodes;\n",
-       "              var allNodes;\n",
-       "              var allEdges;\n",
-       "              var nodeColors;\n",
-       "              var originalNodes;\n",
-       "              var network;\n",
-       "              var container;\n",
-       "              var options, data;\n",
-       "              var filter = {\n",
-       "                  item : '',\n",
-       "                  property : '',\n",
-       "                  value : []\n",
-       "              };\n",
-       "\n",
-       "              \n",
-       "\n",
-       "              \n",
-       "\n",
-       "              // This method is responsible for drawing the graph, returns the drawn network\n",
-       "              function drawGraph() {\n",
-       "                  var container = document.getElementById('mynetwork');\n",
-       "\n",
-       "                  \n",
-       "\n",
-       "                  // parsing and collecting nodes and edges from the python\n",
-       "                  nodes = new vis.DataSet([{\"color\": \"#97c2fc\", \"font\": {\"color\": \"white\"}, \"id\": \"Google\", \"label\": \"Google\", \"shape\": \"dot\"}, {\"color\": \"#97c2fc\", \"font\": {\"color\": \"white\"}, \"id\": \"Google LLC\", \"label\": \"Google LLC\", \"shape\": \"dot\"}, {\"color\": \"#97c2fc\", \"font\": {\"color\": \"white\"}, \"id\": \"summarize emails\", \"label\": \"summarize emails\", \"shape\": \"dot\"}, {\"color\": \"#97c2fc\", \"font\": {\"color\": \"white\"}, \"id\": \"Larry Page\", \"label\": \"Larry Page\", \"shape\": \"dot\"}, {\"color\": \"#97c2fc\", \"font\": {\"color\": \"white\"}, \"id\": \"Sergey Brin\", \"label\": \"Sergey Brin\", \"shape\": \"dot\"}, {\"color\": \"#97c2fc\", \"font\": {\"color\": \"white\"}, \"id\": \"Gemini\", \"label\": \"Gemini\", \"shape\": \"dot\"}]);\n",
-       "                  edges = new vis.DataSet([{\"arrows\": \"to\", \"from\": \"Google LLC\", \"title\": \"FOUNDED_BY\", \"to\": \"Larry Page\"}, {\"arrows\": \"to\", \"from\": \"Google LLC\", \"title\": \"FOUNDED_BY\", \"to\": \"Sergey Brin\"}, {\"arrows\": \"to\", \"from\": \"Google\", \"title\": \"HAS_PRODUCT\", \"to\": \"Gemini\"}, {\"arrows\": \"to\", \"from\": \"Gemini\", \"title\": \"HAS_FEATURE\", \"to\": \"summarize emails\"}]);\n",
-       "\n",
-       "                  nodeColors = {};\n",
-       "                  allNodes = nodes.get({ returnType: \"Object\" });\n",
-       "                  for (nodeId in allNodes) {\n",
-       "                    nodeColors[nodeId] = allNodes[nodeId].color;\n",
-       "                  }\n",
-       "                  allEdges = edges.get({ returnType: \"Object\" });\n",
-       "                  // adding nodes and edges to the graph\n",
-       "                  data = {nodes: nodes, edges: edges};\n",
-       "\n",
-       "                  var options = {\n",
-       "    \"configure\": {\n",
-       "        \"enabled\": false\n",
-       "    },\n",
-       "    \"edges\": {\n",
-       "        \"color\": {\n",
-       "            \"inherit\": true\n",
-       "        },\n",
-       "        \"smooth\": {\n",
-       "            \"enabled\": true,\n",
-       "            \"type\": \"dynamic\"\n",
-       "        }\n",
-       "    },\n",
-       "    \"interaction\": {\n",
-       "        \"dragNodes\": true,\n",
-       "        \"hideEdgesOnDrag\": false,\n",
-       "        \"hideNodesOnDrag\": false\n",
-       "    },\n",
-       "    \"physics\": {\n",
-       "        \"enabled\": true,\n",
-       "        \"stabilization\": {\n",
-       "            \"enabled\": true,\n",
-       "            \"fit\": true,\n",
-       "            \"iterations\": 1000,\n",
-       "            \"onlyDynamicEdges\": false,\n",
-       "            \"updateInterval\": 50\n",
-       "        }\n",
-       "    }\n",
-       "};\n",
-       "\n",
-       "                  \n",
-       "\n",
-       "\n",
-       "                  \n",
-       "\n",
-       "                  network = new vis.Network(container, data, options);\n",
-       "\n",
-       "                  \n",
-       "\n",
-       "                  \n",
-       "\n",
-       "                  \n",
-       "\n",
-       "\n",
-       "                  \n",
-       "\n",
-       "                  return network;\n",
-       "\n",
-       "              }\n",
-       "              drawGraph();\n",
-       "        </script>\n",
-       "    </body>\n",
-       "</html>"
-      ]
-     },
-     "metadata": {}
-    }
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "pM7TmfI0TEFy"
+   },
    "source": [
     "#### Clean up the graph\n",
     "\n",
     "> USE IT WITH CAUTION!\n",
     "\n",
     "Clean up all the nodes/edges in your graph and remove your graph definition."
-   ],
-   "metadata": {
-    "id": "pM7TmfI0TEFy"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "graph_store.cleanup()"
-   ],
+   "execution_count": 36,
    "metadata": {
-    "id": "UQWq4-sITOgl",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "UQWq4-sITOgl",
     "outputId": "5ed5ebf2-a34b-400e-a171-71b2e863e99c"
    },
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Waiting for DDL operations to complete...\n",
       "Waiting for DDL operations to complete...\n",
       "Waiting for DDL operations to complete...\n"
      ]
     }
+   ],
+   "source": [
+    "graph_store.cleanup()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/graph_store.ipynb
+++ b/docs/graph_store.ipynb
@@ -220,7 +220,7 @@
     }
    ],
    "source": [
-    "# @title Get graph documents from Wikipedia & YouTube\n",
+    "# Get graph documents from Wikipedia & YouTube\n",
     "from langchain_community.document_loaders import WikipediaLoader, YoutubeLoader\n",
     "from langchain_experimental.graph_transformers import LLMGraphTransformer\n",
     "from langchain_google_vertexai.llms import VertexAI\n",
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 1,
    "metadata": {
     "id": "C-I8VTIcO442"
    },
@@ -541,13 +541,6 @@
    "source": [
     "graph_store.cleanup()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/langchain_google_spanner/graph_store.py
+++ b/src/langchain_google_spanner/graph_store.py
@@ -79,11 +79,11 @@ def partition_graph_docs(
 ) -> Tuple[dict, dict]:
     """Returns nodes and edges grouped by the type.
 
-    Parameters:
-    - graph_documents: List[GraphDocument]
+    Args:
+      graph_documents: List[GraphDocument].
 
     Returns:
-    - A tuple of two dictionaries. The first is nodes grouped by node types,
+      A tuple of two dictionaries. The first is nodes grouped by node types,
       the second is edges grouped by edge types.
     """
     nodes: CaseInsensitiveDict[dict[NodeWrapper, Node]] = CaseInsensitiveDict()
@@ -131,10 +131,10 @@ class GraphDocumentUtility:
 
     @staticmethod
     def fixup_graph_documents(graph_documents: List[GraphDocument]) -> None:
-        """Preprocess graph documents
+        """Preprocess graph documents.
 
-        Parameters:
-        - graph_documents: List[GraphDocument]
+        Args:
+          graph_documents: List[GraphDocument].
         """
         for graph_document in graph_documents:
             for node in graph_document.nodes:
@@ -144,10 +144,10 @@ class GraphDocumentUtility:
 
     @staticmethod
     def fixup_element(element: Union[Node, Relationship]) -> None:
-        """Preprocess graph element
+        """Preprocess graph element.
 
-        Parameters:
-        - element: Node or Relationship
+        Args:
+          element: Node or Relationship.
         """
         element.type = GraphDocumentUtility.fixup_identifier(element.type)
         should_ignore = lambda v: v is None or (isinstance(v, list) and len(v) == 0)
@@ -250,17 +250,20 @@ class ElementSchema(object):
 
     @staticmethod
     def from_static_nodes(
-        name: str, graph_name: str, nodes: List[Node]
+        name: str, nodes: List[Node], graph_schema: SpannerGraphSchema
     ) -> ElementSchema:
         """Builds ElementSchema from a list of nodes.
 
-        Parameters:
-        - name: name of the schema;
-        - graph_name: name of the graph;
-        - nodes: a non-empty list of nodes.
+        Args:
+          name: name of the schema.
+          nodes: a non-empty list of nodes.
+          graph_schema: schema of the graph.
 
         Returns:
-        - ElementSchema: schema representation of the nodes.
+          ElementSchema: schema representation of the nodes.
+
+        Raises:
+          ValueError: An error occured building element schema.
         """
         if len(nodes) == 0:
             raise ValueError("The list of nodes should not be empty")
@@ -280,7 +283,9 @@ class ElementSchema(object):
         types[ElementSchema.NODE_KEY_COLUMN_NAME] = TypeUtility.value_to_param_type(
             nodes[0].id
         )
-        return ElementSchema.make_node_schema(name, name, graph_name, types)
+        return ElementSchema.make_node_schema(
+            name, name, graph_schema.graph_name, types
+        )
 
     @staticmethod
     def from_dynamic_nodes(
@@ -288,13 +293,16 @@ class ElementSchema(object):
     ) -> ElementSchema:
         """Builds ElementSchema from a list of nodes.
 
-        Parameters:
-        - name: name of the schema;
-        - graph_name: name of the graph;
-        - nodes: a non-empty list of nodes.
+        Args:
+          name: name of the schema;
+          nodes: a non-empty list of nodes.
+          graph_schema: schema of the graph;
 
         Returns:
-        - ElementSchema: schema representation of the nodes.
+          ElementSchema: schema representation of the nodes.
+
+        Raises:
+          ValueError: An error occured building element schema.
         """
         if len(nodes) == 0:
             raise ValueError("The list of nodes should not be empty")
@@ -325,19 +333,21 @@ class ElementSchema(object):
     @staticmethod
     def from_static_edges(
         name: str,
-        graph_name: str,
         edges: List[Relationship],
         graph_schema: SpannerGraphSchema,
     ) -> ElementSchema:
         """Builds ElementSchema from a list of edges.
 
-        Parameters:
-        - name: name of the schema;
-        - graph_name: name of the graph;
-        - nodes: a non-empty list of edges.
+        Args:
+          name: name of the schema;
+          edges: a non-empty list of edges.
+          graph_schema: schema of the graph;
 
         Returns:
-        - ElementSchema: schema representation of the edges.
+          ElementSchema: schema representation of the edges.
+
+        Raises:
+          ValueError: An error occured building element schema.
         """
         if len(edges) == 0:
             raise ValueError("The list of edges should not be empty")
@@ -386,13 +396,16 @@ class ElementSchema(object):
     ) -> ElementSchema:
         """Builds ElementSchema from a list of edges.
 
-        Parameters:
-        - name: name of the schema;
-        - graph_name: name of the graph;
-        - edges: a non-empty list of edges.
+        Args:
+          name: name of the schema.
+          edges: a non-empty list of edges.
+          graph_schema: schema of the graph.
 
         Returns:
-        - ElementSchema: schema representation of the edges.
+          ElementSchema: schema representation of the edges.
+
+        Raises:
+          ValueError: An error occured building element schema.
         """
         if len(edges) == 0:
             raise ValueError("The list of edges should not be empty")
@@ -438,14 +451,18 @@ class ElementSchema(object):
     ) -> Generator[Tuple[str, Tuple[str], List[List[Any]]], None, None]:
         """Builds the data required to add a list of nodes to Spanner.
 
-        Parameters:
-          - name: type of name;
-          - nodes: a list of Nodes.
+        Args:
+          name: type of name;
+          nodes: a list of Nodes.
 
-        Returns an iterator that yields a tuple consists of the following:
-          - str: a table name;
-          - List[str]: a list of column names;
-          - List[List[Any]]: a list of rows.
+        Returns:
+          An iterator that yields a tuple consists of the following:
+            str: a table name;
+            List[str]: a list of column names;
+            List[List[Any]]: a list of rows.
+
+        Raises:
+          ValueError: An error occured adding nodes.
         """
         if len(nodes) == 0:
             raise ValueError("Empty list of nodes")
@@ -483,14 +500,18 @@ class ElementSchema(object):
     ) -> Generator[Tuple[str, Tuple[str], List[List[Any]]], None, None]:
         """Builds the data required to add a list of edges to Spanner.
 
-        Parameters:
-          - name: type of edge;
-          - edges: a list of Relationships.
+        Args:
+          name: type of edge;
+          edges: a list of Relationships.
 
-        Returns an iterator that yields a tuple consists of the following:
-          - str: a table name;
-          - List[str]: a list of column names;
-          - List[List[Any]]: a list of rows.
+        Returns:
+          An iterator that yields a tuple consists of the following:
+            str: a table name;
+            List[str]: a list of column names;
+            List[List[Any]]: a list of rows.
+
+        Raises:
+          ValueError: An error occured adding edges.
         """
         if len(edges) == 0:
             raise ValueError("Empty list of edges")
@@ -531,13 +552,16 @@ class ElementSchema(object):
     ) -> ElementSchema:
         """Builds ElementSchema from information schema represenation of an element.
 
-        Parameters:
-        - element_schema: the information schema represenation of an element;
-        - property_decls: the information schema represenation of property
-          declarations.
+        Args:
+          element_schema: the information schema represenation of an element;
+          property_decls: the information schema represenation of property
+            declarations.
 
         Returns:
-        - ElementSchema
+          ElementSchema
+
+        Raises:
+          ValueError: An error occured building graph schema.
         """
         element = ElementSchema()
         element.name = element_schema["name"]
@@ -579,9 +603,14 @@ class ElementSchema(object):
     def to_ddl(self, graph_schema: SpannerGraphSchema) -> str:
         """Returns a CREATE TABLE ddl that represents the element schema.
 
+        Args:
+          graph_schema: Spanner Graph schema.
+
         Returns:
-        - str: a string of CREATE TABLE ddl statement.
-        - graph_schema: Spanner Graph schema.
+          str: a string of CREATE TABLE ddl statement.
+
+        Raises:
+          ValueError: An error occured building graph ddl.
         """
 
         to_identifier = GraphDocumentUtility.to_identifier
@@ -631,11 +660,14 @@ class ElementSchema(object):
     def evolve(self, new_schema: ElementSchema) -> List[str]:
         """Evolves current schema from the new schema.
 
-        Parameters:
-        - new_schema: an ElementSchema representing new nodes/edges.
+        Args:
+          new_schema: an ElementSchema representing new nodes/edges.
 
         Returns:
-        - List[str]: a list of DDL statements.
+          List[str]: a list of DDL statements.
+
+        Raises:
+          ValueError: An error occured evolving graph schema.
         """
         if self.kind != new_schema.kind:
             raise ValueError(
@@ -725,14 +757,14 @@ class SpannerGraphSchema(object):
     ):
         """Initializes the graph schema.
 
-        Parameters:
-        - graph_name: the name of the graph;
-        - use_flexible_schema: whether to use the flexible schema which uses a
-          JSON blob to store node and edge properties;
-        - static_node_properties: in flexible schema, treat these node
-          properties as static;
-        - static_edge_properties: in flexible schema, treat these edge
-          properties as static.
+        Args:
+          graph_name: the name of the graph;
+          use_flexible_schema: whether to use the flexible schema which uses a
+            JSON blob to store node and edge properties;
+          static_node_properties: in flexible schema, treat these node
+            properties as static;
+          static_edge_properties: in flexible schema, treat these edge
+            properties as static.
         """
         self.graph_name: str = graph_name
         self.nodes: CaseInsensitiveDict[ElementSchema] = CaseInsensitiveDict({})
@@ -748,18 +780,18 @@ class SpannerGraphSchema(object):
     def evolve(self, graph_documents: List[GraphDocument]) -> List[str]:
         """Evolves current schema into a schema representing the input documents.
 
-        Parameters:
-        - graph_documents: a list of GraphDocument.
+        Args:
+          graph_documents: a list of GraphDocument.
 
         Returns:
-        - List[str]: a list of DDL statements.
+          List[str]: a list of DDL statements.
         """
         nodes, edges = partition_graph_docs(graph_documents)
 
         ddls = []
         for k, ns in nodes.items():
             node_schema = (
-                ElementSchema.from_static_nodes(k, self.graph_name, ns)
+                ElementSchema.from_static_nodes(k, ns, self)
                 if not self.use_flexible_schema
                 else ElementSchema.from_dynamic_nodes(k, ns, self)
             )
@@ -768,7 +800,7 @@ class SpannerGraphSchema(object):
 
         for k, es in edges.items():
             edge_schema = (
-                ElementSchema.from_static_edges(k, self.graph_name, es, self)
+                ElementSchema.from_static_edges(k, es, self)
                 if not self.use_flexible_schema
                 else ElementSchema.from_dynamic_edges(k, es, self)
             )
@@ -782,8 +814,8 @@ class SpannerGraphSchema(object):
     def from_information_schema(self, info_schema: Dict[str, Any]) -> None:
         """Builds the schema from information schema represenation.
 
-        Parameters:
-        - info_schema: the information schema represenation of a graph;
+        Args:
+          info_schema: the information schema represenation of a graph;
         """
         property_decls = info_schema.get("propertyDeclarations", [])
         for node in info_schema["nodeTables"]:
@@ -799,44 +831,44 @@ class SpannerGraphSchema(object):
     def get_node_schema(self, name: str) -> Optional[ElementSchema]:
         """Gets the node schema by name.
 
-        Parameters:
-        - name: the node schema name.
+        Args:
+          name: the node schema name.
 
         Returns:
-        - Optional[ElementSchema]: returns None if there is no such node schema.
+          Optional[ElementSchema]: returns None if there is no such node schema.
         """
         return self.nodes.get(name, None)
 
     def get_edge_schema(self, name: str) -> Optional[ElementSchema]:
         """Gets the edge schema by name.
 
-        Parameters:
-        - name: the edge schema name.
+        Args:
+          name: the edge schema name.
 
         Returns:
-        - Optional[ElementSchema]: returns None if there is no such edge schema.
+          Optional[ElementSchema]: returns None if there is no such edge schema.
         """
         return self.edges.get(name, None)
 
     def get_property_type(self, name: str) -> Optional[param_types.Type]:
         """Gets the property type by name.
 
-        Parameters:
-        - name: the property name.
+        Args:
+          name: the property name.
 
         Returns:
-        - Optional[param_types.Type]: returns None if there is no such property.
+          Optional[param_types.Type]: returns None if there is no such property.
         """
         return self.properties.get(name, None)
 
     def get_properties_as_struct_type(self, properties: List[str]) -> param_types.Type:
         """Gets the struct type with properties as fields.
 
-        Parameters:
-        - properties: a list of property names.
+        Args:
+          properties: a list of property names.
 
         Returns:
-        - param_types.Struct: a struct type with properties as fields.
+          param_types.Struct: a struct type with properties as fields.
         """
         struct_fields = []
         for p in properties:
@@ -852,7 +884,7 @@ class SpannerGraphSchema(object):
         """Builds a string representation of the graph schema.
 
         Returns:
-        - str: a string representation of the graph schema.
+          str: a string representation of the graph schema.
         """
         properties = {
             k: TypeUtility.spanner_type_to_schema_str(v)
@@ -901,7 +933,7 @@ class SpannerGraphSchema(object):
         """Returns a CREATE PROPERTY GRAPH ddl that represents the graph schema.
 
         Returns:
-        - str: a string of CREATE PROPERTY GRAPH ddl statement.
+          str: a string of CREATE PROPERTY GRAPH ddl statement.
         """
         to_identifier = GraphDocumentUtility.to_identifier
         to_identifiers = GraphDocumentUtility.to_identifiers
@@ -994,11 +1026,11 @@ class SpannerGraphSchema(object):
     def _update_node_schema(self, node_schema: ElementSchema) -> List[str]:
         """Evolves node schema.
 
-        Parameters:
-        - node_schema: a node ElementSchema.
+        Args:
+          node_schema: a node ElementSchema.
 
         Returns:
-        - List[str]: a list of DDL statements that requires to evolve the schema.
+          List[str]: a list of DDL statements that requires to evolve the schema.
         """
 
         old_schema = self.node_tables.get(node_schema.name, None)
@@ -1014,11 +1046,11 @@ class SpannerGraphSchema(object):
     def _update_edge_schema(self, edge_schema: ElementSchema) -> List[str]:
         """Evolves edge schema.
 
-        Parameters:
-        - edge_schema: an edge ElementSchema.
+        Args:
+          edge_schema: an edge ElementSchema.
 
         Returns:
-        - List[str]: a list of DDL statements that requires to evolve the schema.
+          List[str]: a list of DDL statements that requires to evolve the schema.
         """
         if edge_schema.base_table_name not in self.edge_tables:
             ddls = [edge_schema.to_ddl(self)]
@@ -1034,8 +1066,8 @@ class SpannerGraphSchema(object):
     def _update_labels_and_properties(self, element_schema: ElementSchema) -> None:
         """Updates labels and properties based on an element schema.
 
-        Parameters:
-        - element_schema: an ElementSchema.
+        Args:
+          element_schema: an ElementSchema.
         """
         for l in element_schema.labels:
             if l in self.labels:
@@ -1050,14 +1082,15 @@ class SpannerGraphSchema(object):
     ) -> Generator[Tuple[str, Tuple[str], List[List[Any]]], None, None]:
         """Builds the data required to add a list of nodes to Spanner.
 
-        Parameters:
-          - name: type of name;
-          - nodes: a list of Nodes.
+        Args:
+          name: type of name;
+          nodes: a list of Nodes.
 
-        Returns an iterator that yields a tuple consists of the following:
-          - str: a table name;
-          - List[str]: a list of column names;
-          - List[List[Any]]: a list of rows.
+        Returns:
+          An iterator that yields a tuple consists of the following:
+            str: a table name;
+            List[str]: a list of column names;
+            List[List[Any]]: a list of rows.
         """
         node_schema = self.get_node_schema(name)
         if node_schema is None:
@@ -1070,14 +1103,15 @@ class SpannerGraphSchema(object):
     ) -> Generator[Tuple[str, Tuple[str], List[List[Any]]], None, None]:
         """Builds the data required to add a list of edges to Spanner.
 
-        Parameters:
-          - name: type of edge;
-          - edges: a list of Relationships.
+        Args:
+          name: type of edge;
+          edges: a list of Relationships.
 
-        Returns an iterator that yields a tuple consists of the following:
-          - str: a table name;
-          - List[str]: a list of column names;
-          - List[List[Any]]: a list of rows.
+        Returns:
+          An iterator that yields a tuple consists of the following:
+            str: a table name;
+            List[str]: a list of column names;
+            List[List[Any]]: a list of rows.
         """
         edge_schema = self.get_edge_schema(name)
         if edge_schema is None:
@@ -1086,8 +1120,48 @@ class SpannerGraphSchema(object):
             yield v
 
 
-class SpannerImpl(object):
+class SpannerInterface(object):
     """Wrapper of Spanner APIs."""
+
+    @abstractmethod
+    def query(self, query: str, params: dict = {}) -> List[Dict[str, Any]]:
+        """Runs a Spanner query.
+
+        Args:
+          query: query string;
+          params: Spanner query params;
+          param_types: Spanner param types.
+
+        Returns:
+          List[Dict[str, Any]]: query results.
+        """
+        pass
+
+    @abstractmethod
+    def apply_ddls(self, ddls: List[str], options: Dict[str, Any] = {}) -> None:
+        """Applies a list of schema modifications.
+
+        Args:
+          ddls: Spanner Schema DDLs.
+        """
+        pass
+
+    @abstractmethod
+    def insert_or_update(
+        self, table: str, columns: Tuple[str], values: List[List[Any]]
+    ) -> None:
+        """Insert or update the table.
+
+        Args:
+          table: Spanner table name;
+          columns: a tuple of column names;
+          values: list of values.
+        """
+        pass
+
+
+class SpannerImpl(SpannerInterface):
+    """Implementation of SpannerInterface."""
 
     def __init__(
         self,
@@ -1097,27 +1171,16 @@ class SpannerImpl(object):
     ):
         """Initializes the Spanner implementation.
 
-        Parameters:
-        - instance_id: Google Cloud Spanner instance id;
-        - database_id: Google Cloud Spanner database id;
-        - client: an optional instance of Spanner client.
+        Args:
+          instance_id: Google Cloud Spanner instance id;
+          database_id: Google Cloud Spanner database id;
+          client: an optional instance of Spanner client.
         """
         self.client = client or spanner.Client()
         self.instance = self.client.instance(instance_id)
         self.database = self.instance.database(database_id)
 
     def query(self, query: str, params: dict = {}) -> List[Dict[str, Any]]:
-        """Runs a Spanner query.
-
-        Parameters:
-        - query: query string;
-        - params: Spanner query params;
-        - param_types: Spanner param types.
-
-        Returns:
-        - List[Dict[str, Any]]: query results.
-        """
-
         param_types = {k: TypeUtility.value_to_param_type(v) for k, v in params.items()}
         with self.database.snapshot() as snapshot:
             rows = snapshot.execute_sql(query, params=params, param_types=param_types)
@@ -1132,11 +1195,6 @@ class SpannerImpl(object):
             ]
 
     def apply_ddls(self, ddls: List[str], options: Dict[str, Any] = {}) -> None:
-        """Applies a list of schema modifications.
-
-        Parameters:
-        - ddls: Spanner Schema DDLs.
-        """
         if not ddls:
             return
 
@@ -1147,14 +1205,6 @@ class SpannerImpl(object):
     def insert_or_update(
         self, table: str, columns: Tuple[str], values: List[List[Any]]
     ) -> None:
-        """Insert or update the table.
-
-        Parameters:
-        - table: Spanner table name;
-        - columns: a tuple of column names;
-        - values: list of values.
-        """
-
         for i in range(0, len(values), MUTATION_BATCH_SIZE):
             value_batch = values[i : i + MUTATION_BATCH_SIZE]
             with self.database.batch() as batch:
@@ -1173,21 +1223,23 @@ class SpannerGraphStore(GraphStore):
         use_flexible_schema: bool = False,
         static_node_properties: List[str] = [],
         static_edge_properties: List[str] = [],
+        impl: Optional[SpannerInterface] = None,
     ):
-        """Parameters:
+        """Initializes SpannerGraphStore.
 
-        - instance_id: Google Cloud Spanner instance id;
-        - database_id: Google Cloud Spanner database id;
-        - graph_name: Graph name;
-        - client: an optional instance of Spanner client.
-        - use_flexible_schema: whether to use the flexible schema which uses a
+        Args:
+          instance_id: Google Cloud Spanner instance id;
+          database_id: Google Cloud Spanner database id;
+          graph_name: Graph name;
+          client: an optional instance of Spanner client.
+          use_flexible_schema: whether to use the flexible schema which uses a
           JSON blob to store node and edge properties;
-        - static_node_properties: in flexible schema, treat these node
+          static_node_properties: in flexible schema, treat these node
           properties as static;
-        - static_edge_properties: in flexible schema, treat these edge
+          static_edge_properties: in flexible schema, treat these edge
           properties as static.
         """
-        self.impl = SpannerImpl(instance_id, database_id, client)
+        self.impl = impl or SpannerImpl(instance_id, database_id, client)
         self.schema = SpannerGraphSchema(
             graph_name,
             use_flexible_schema,
@@ -1205,10 +1257,10 @@ class SpannerGraphStore(GraphStore):
     ) -> None:
         """Constructs nodes and relationships in the graph based on the provided docs.
 
-        Parameters:
-        - graph_documents (List[GraphDocument]): A list of GraphDocument objects
-        that contain the nodes and relationships to be added to the graph. Each
-        GraphDocument should encapsulate the structure of part of the graph,
+        Args:
+          graph_documents (List[GraphDocument]): A list of GraphDocument objects
+            that contain the nodes and relationships to be added to the graph. Each
+            GraphDocument should encapsulate the structure of part of the graph,
         """
         if include_source:
             raise NotImplementedError("include_source is not supported yet")
@@ -1242,13 +1294,13 @@ class SpannerGraphStore(GraphStore):
     def query(self, query: str, params: dict = {}) -> List[Dict[str, Any]]:
         """Query Spanner database.
 
-        Parameters:
-            query (str): The query to execute.
-            params (dict): The parameters to pass to the query.
+        Args:
+          query (str): The query to execute.
+          params (dict): The parameters to pass to the query.
 
         Returns:
-            List[Dict[str, Any]]: The list of dictionaries containing the query
-            results.
+          List[Dict[str, Any]]: The list of dictionaries containing the query
+          results.
         """
         return self.impl.query(query, params)
 

--- a/src/langchain_google_spanner/graph_store.py
+++ b/src/langchain_google_spanner/graph_store.py
@@ -14,15 +14,14 @@
 
 from __future__ import annotations
 
+import json
 import re
 import string
 from abc import abstractmethod
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
-import json
 
 from google.cloud import spanner
-from google.cloud.spanner_v1 import param_types
-from google.cloud.spanner_v1 import JsonObject
+from google.cloud.spanner_v1 import JsonObject, param_types
 from langchain_community.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_community.graphs.graph_store import GraphStore
 from requests.structures import CaseInsensitiveDict

--- a/src/langchain_google_spanner/graph_store.py
+++ b/src/langchain_google_spanner/graph_store.py
@@ -33,7 +33,7 @@ MUTATION_BATCH_SIZE = 1000
 DEFAULT_DDL_TIMEOUT = 300
 NODE_KIND = "NODE"
 EDGE_KIND = "EDGE"
-USER_AGENT_GRAPH_STORE = "langchain-google-spanner-python:graph_store/" + __version__
+USER_AGENT_GRAPH_STORE = "langchain-google-spanner-python:graphstore/" + __version__
 
 
 class NodeWrapper(object):

--- a/src/langchain_google_spanner/graph_store.py
+++ b/src/langchain_google_spanner/graph_store.py
@@ -169,7 +169,6 @@ class ElementSchema(object):
     TARGET_NODE_KEY_COLUMN_NAME: str = "target_id"
     DYNAMIC_PROPERTY_COLUMN_NAME: str = "properties"
     DYNAMIC_LABEL_COLUMN_NAME: str = "label"
-    UUID_COLUMN_NAME: str = "default_uuid"
 
     name: str
     original_name: str
@@ -310,7 +309,6 @@ class ElementSchema(object):
         for col_name in [
             ElementSchema.NODE_KEY_COLUMN_NAME,
             ElementSchema.TARGET_NODE_KEY_COLUMN_NAME,
-            ElementSchema.UUID_COLUMN_NAME,
         ]:
             if col_name in edge.types:
                 raise ValueError(
@@ -323,7 +321,6 @@ class ElementSchema(object):
         edge.types[ElementSchema.TARGET_NODE_KEY_COLUMN_NAME] = (
             TypeUtility.value_to_param_type(edges[0].target.id)
         )
-        edge.types[ElementSchema.UUID_COLUMN_NAME] = param_types.STRING
 
         edge.properties = CaseInsensitiveDict({prop: prop for prop in edge.types})
 
@@ -332,7 +329,6 @@ class ElementSchema(object):
         edge.key_columns = [
             ElementSchema.NODE_KEY_COLUMN_NAME,
             ElementSchema.TARGET_NODE_KEY_COLUMN_NAME,
-            ElementSchema.UUID_COLUMN_NAME,
         ]
 
         edge.original_name = name
@@ -383,7 +379,6 @@ class ElementSchema(object):
             {
                 ElementSchema.DYNAMIC_PROPERTY_COLUMN_NAME: param_types.JSON,
                 ElementSchema.DYNAMIC_LABEL_COLUMN_NAME: param_types.STRING,
-                ElementSchema.UUID_COLUMN_NAME: param_types.STRING,
                 ElementSchema.NODE_KEY_COLUMN_NAME: TypeUtility.value_to_param_type(
                     edges[0].source.id
                 ),
@@ -410,7 +405,6 @@ class ElementSchema(object):
             ElementSchema.NODE_KEY_COLUMN_NAME,
             ElementSchema.TARGET_NODE_KEY_COLUMN_NAME,
             ElementSchema.DYNAMIC_LABEL_COLUMN_NAME,
-            ElementSchema.UUID_COLUMN_NAME,
         ]
 
         edge.original_name = name
@@ -494,7 +488,7 @@ class ElementSchema(object):
         if len(edges) == 0:
             raise ValueError("Empty list of edges")
 
-        columns = [k for k in self.types.keys() if k != ElementSchema.UUID_COLUMN_NAME]
+        columns = [k for k in self.types.keys()]
         rows = []
         for edge in edges:
             properties = edge.properties.copy()
@@ -591,15 +585,10 @@ class ElementSchema(object):
             to_identifier(self.base_table_name),
             ",\n                ".join(
                 (
-                    "{} {} {}".format(
+                    "{} {}".format(
                         to_identifier(n),
                         TypeUtility.spanner_type_to_schema_str(
                             t, include_type_annotations=True
-                        ),
-                        (
-                            "DEFAULT (GENERATE_UUID())"
-                            if n == ElementSchema.UUID_COLUMN_NAME
-                            else ""
                         ),
                     )
                     for n, t in self.types.items()

--- a/src/langchain_google_spanner/graph_store.py
+++ b/src/langchain_google_spanner/graph_store.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import re
 import string
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any, Dict, Generator, Iterable, List, Mapping, Optional, Tuple, Union
 
 from google.cloud import spanner
@@ -1120,7 +1120,7 @@ class SpannerGraphSchema(object):
             yield v
 
 
-class SpannerInterface(object):
+class SpannerInterface(ABC):
     """Wrapper of Spanner APIs."""
 
     @abstractmethod
@@ -1135,7 +1135,7 @@ class SpannerInterface(object):
         Returns:
           List[Dict[str, Any]]: query results.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def apply_ddls(self, ddls: List[str], options: Dict[str, Any] = {}) -> None:
@@ -1144,7 +1144,7 @@ class SpannerInterface(object):
         Args:
           ddls: Spanner Schema DDLs.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def insert_or_update(
@@ -1157,7 +1157,7 @@ class SpannerInterface(object):
           columns: a tuple of column names;
           values: list of values.
         """
-        pass
+        raise NotImplementedError
 
 
 class SpannerImpl(SpannerInterface):

--- a/src/langchain_google_spanner/type_utils.py
+++ b/src/langchain_google_spanner/type_utils.py
@@ -18,8 +18,7 @@ import base64
 import datetime
 from typing import Any
 
-from google.cloud.spanner_v1 import param_types
-from google.cloud.spanner_v1 import JsonObject
+from google.cloud.spanner_v1 import JsonObject, param_types
 
 
 class TypeUtility(object):

--- a/tests/integration/test_spanner_graph_store.py
+++ b/tests/integration/test_spanner_graph_store.py
@@ -17,8 +17,8 @@ import datetime
 import os
 import random
 import string
-import pytest
 
+import pytest
 from google.cloud.spanner import Client  # type: ignore
 from google.cloud.spanner_v1 import JsonObject
 from langchain_community.graphs.graph_document import GraphDocument, Node, Relationship


### PR DESCRIPTION
feat(graph): Extension to SpannerGraphStore

Many use cases don't have a clean pre-specified schema, hence this change adds support to generic flexible graph schema.

1) Allow a dynamic schema for nodes and edges:
  - both nodes and edges are stored in one table with dynamic label and properties (JSON)
2) Allow more than one (src.node.id, target.node.id, edge.type) by introducing a uuid as part of the key;
3) Prefix the table names with graph names to avoid conflicting.
4) Add json type support.

Fixes #<issue_number_goes_here> 🦕
