### PR TITLE
fix: handle unspecified column_configs for KNN

### DIFF
--- a/src/langchain_google_spanner/vector_store.py
+++ b/src/langchain_google_spanner/vector_store.py
@@ -440,7 +440,7 @@ class SpannerVectorStore(VectorStore):
         """
 
         embedding_config = list(
-            filter(lambda x: x.name == embedding_column, column_configs)
+            filter(lambda x: x.name == embedding_column, column_configs or [])
         )
         if embedding_column and len(embedding_config) > 0:
             config = embedding_config[0]

--- a/tests/integration/test_spanner_vector_store.py
+++ b/tests/integration/test_spanner_vector_store.py
@@ -90,6 +90,22 @@ class TestStaticUtilityGoogleSQL_KNN:
     def setup_database(self, client, cleanupGSQL):
         yield
 
+    def test_init_vector_store_table_with_basic_args(self):
+        SpannerVectorStore.init_vector_store_table(
+            instance_id=instance_id,
+            database_id=google_database,
+            table_name=table_name,
+        )
+
+    def test_init_vector_store_table_with_embeddings(self):
+        embeddings = FakeEmbeddings(size=3)
+        SpannerVectorStore.init_vector_store_table(
+            instance_id=instance_id,
+            database_id=google_database,
+            table_name=table_name,
+            embedding_service=embeddings,
+        )
+
     def test_init_vector_store_table1(self):
         SpannerVectorStore.init_vector_store_table(
             instance_id=instance_id,
@@ -159,6 +175,13 @@ class TestStaticUtilityPGSQL:
     @pytest.fixture(autouse=True)
     def setup_database(self, client, cleanupPGSQL):
         yield
+
+    def test_init_vector_store_basic_args(self):
+        SpannerVectorStore.init_vector_store_table(
+            instance_id=instance_id,
+            database_id=pg_database,
+            table_name=table_name,
+        )
 
     def test_init_vector_store_table1(self):
         SpannerVectorStore.init_vector_store_table(

--- a/tests/integration/test_spanner_vector_store.py
+++ b/tests/integration/test_spanner_vector_store.py
@@ -97,15 +97,6 @@ class TestStaticUtilityGoogleSQL_KNN:
             table_name=table_name,
         )
 
-    def test_init_vector_store_table_with_embeddings(self):
-        embeddings = FakeEmbeddings(size=3)
-        SpannerVectorStore.init_vector_store_table(
-            instance_id=instance_id,
-            database_id=google_database,
-            table_name=table_name,
-            embedding_service=embeddings,
-        )
-
     def test_init_vector_store_table1(self):
         SpannerVectorStore.init_vector_store_table(
             instance_id=instance_id,


### PR DESCRIPTION
Fixes a bug in which we tried to find the embedding columns. The prior integration tests for KNN all had certain fields filled in and hence couldn't catch this case. Thanks to the offline report from Amarnath Mullick.