### PR TITLE
chore: Fix failing lint and test presubmit checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,11 @@ exclude = [
     'docs/*',
     'noxfile.py'
 ]
+
+[[tool.mypy.overrides]]
+module = [
+    "click.*",
+    "anyio.*"
+]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/tests/integration/test_spanner_graph_qa.py
+++ b/tests/integration/test_spanner_graph_qa.py
@@ -37,7 +37,7 @@ def random_string(num_char=3):
 
 def get_llm():
     llm = ChatVertexAI(
-        model="gemini-2.0-flash-001",
+        model="gemini-3-flash-preview",
         temperature=0,
     )
     return llm

--- a/tests/integration/test_spanner_graph_retriever.py
+++ b/tests/integration/test_spanner_graph_retriever.py
@@ -39,7 +39,7 @@ def random_string(num_char=3):
 
 def get_llm():
     llm = ChatVertexAI(
-        model="gemini-2.0-flash-001",
+        model="gemini-3-flash-preview",
         temperature=0,
     )
     return llm


### PR DESCRIPTION
This PR:
- Update integration test gemini models to 3.1 flash preview, using this update [PR](https://github.com/googleapis/langchain-google-spanner-python/pull/201) as reference.
- Add mypy overrides for click & anyio module (skipping these deps as they do not support python3.9 but the library still does)