### PR TITLE
chore: upgrade langchain-core dependency to >=1.0.0 and drop Python 3.9

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -27,10 +27,10 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - "cla/google"
       - "lint"
-      - "integration-test-pr-py39 (langchain-spanner-testing)"
       - "integration-test-pr-py310 (langchain-spanner-testing)"
       - "integration-test-pr-py311 (langchain-spanner-testing)"
       - "integration-test-pr-py312 (langchain-spanner-testing)"
+      - "integration-test-pr-py313 (langchain-spanner-testing)"
       - "conventionalcommits.org"
       - "header-check"
     # - Add required status checks like presubmit tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install requirements
         run: pip install -r requirements.txt

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -65,16 +65,16 @@ ENV BINARY yq_linux_amd64
 RUN wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/bin/yq && \
     chmod +x /usr/bin/yq
 
-###################### Install python 3.9.13
+###################### Install python 3.10.19
 
-# Download python 3.9.13
-RUN wget https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz
+# Download python 3.10.19
+RUN wget https://www.python.org/ftp/python/3.10.19/Python-3.10.19.tgz
 
 # Extract files
-RUN tar -xvf Python-3.9.13.tgz
+RUN tar -xvf Python-3.10.19.tgz
 
-# Install python 3.9.13
-RUN ./Python-3.9.13/configure --enable-optimizations
+# Install python 3.10.19
+RUN ./Python-3.10.19/configure --enable-optimizations
 RUN make altinstall
 
 ###################### Install pip

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -34,11 +34,11 @@ These tests are registered as required tests in `.github/sync-repo-settings.yaml
 
 #### Trigger Setup
 
-Cloud Build triggers (for Python versions 3.9 to 3.11) were created with the following specs:
+Cloud Build triggers (for Python versions 3.10 to 3.13) were created with the following specs:
 
 ```YAML
-name: integration-test-pr-py39
-description: Run integration tests on PR for Python 3.9
+name: integration-test-pr-py310
+description: Run integration tests on PR for Python 3.10
 filename: integration.cloudbuild.yaml
 github:
   name: langchain-google-spanner-python
@@ -55,7 +55,7 @@ substitutions:
   _INSTANCE_ID: <ADD_VALUE>
   _PG_DATABASE: <ADD_VALUE>
   _GOOGLE_DATABASE: <ADD_VALUE>
-  _VERSION: "3.9"
+  _VERSION: "3.10"
 ```
 
 Use `gcloud builds triggers import --source=trigger.yaml` to create triggers via the command line

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ With `virtualenv`_, it’s possible to install this library without needing syst
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Python >= 3.9
+Python >= 3.10
 
 Mac/Linux
 ^^^^^^^^^

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -38,7 +38,7 @@ substitutions:
   _INSTANCE_ID: test-instance
   _GOOGLE_DATABASE: test-gsql-db
   _PG_DATABASE: test-pgsql-db
-  _VERSION: "3.9"
+  _VERSION: "3.10"
 
 options:
   dynamicSubstitutions: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,10 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    "langchain-core>=0.1.25, <1.0.0",
-    "langchain>=0.1.0, <1.0.0",
-    "langchain-openai>=0.1.0, <1.0.0",
+    "langchain-core>=1.0.0, <2.0.0",
+    "langchain>=1.0.0, <2.0.0",
+    "langchain-openai>=1.0.0, <2.0.0",
+    "langchain-classic>=1.0.0, <2.0.0",
     "google-cloud-spanner>=3.41.0, <4.0.0",
     "pydantic>=2.9.1, <3.0.0",
     "numpy>=1.22.4, <3.0.0"
@@ -52,7 +53,7 @@ test = [
     "pytest==8.4.1",
     "pytest-asyncio==0.26.0",
     "pytest-cov==5.0.0",
-    "langchain_google_vertexai==2.0.27"
+    "langchain_google_vertexai>=3.0.0, <4.0.0"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "LangChain integrations for Google Cloud Spanner"
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
@@ -21,10 +21,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.setuptools.dynamic]
@@ -60,13 +60,13 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"
 
 [tool.mypy]
-python_version = 3.9
+python_version = "3.10"
 warn_unused_configs = true
 follow_imports = "skip"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-google-cloud-spanner==3.55.0
-langchain-core==0.3.86
-langchain==0.3.30
-langchain-openai==0.3.15
-pydantic==2.11.7
+google-cloud-spanner==3.69.0
+langchain-core==1.4.9
+langchain==1.3.14
+langchain-openai==1.3.5
+langchain-classic==1.0.8
+pydantic==2.13.4
 numpy==1.26.4

--- a/src/langchain_google_spanner/graph_qa.py
+++ b/src/langchain_google_spanner/graph_qa.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from langchain.chains.base import Chain
+from langchain_classic.chains.base import Chain
 from langchain_core.callbacks import CallbackManagerForChainRun
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import JsonOutputParser, StrOutputParser

--- a/src/langchain_google_spanner/graph_retriever.py
+++ b/src/langchain_google_spanner/graph_retriever.py
@@ -15,7 +15,6 @@
 import json
 from typing import Any, List, Optional
 
-from langchain.schema.retriever import BaseRetriever
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -25,6 +24,7 @@ from langchain_core.load import dumps
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import FewShotPromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
+from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import RunnableSequence
 from langchain_core.vectorstores import InMemoryVectorStore
 from pydantic import Field

--- a/tests/integration/test_spanner_graph_qa.py
+++ b/tests/integration/test_spanner_graph_qa.py
@@ -18,7 +18,7 @@ import string
 
 import pytest
 from google.cloud import spanner
-from langchain.evaluation import load_evaluator
+from langchain_classic.evaluation import load_evaluator
 from langchain_core.documents import Document
 from langchain_google_vertexai import ChatVertexAI, VertexAIEmbeddings
 


### PR DESCRIPTION
This PR upgrades the langchain-core dependency and updates Python version support.

Closes: https://github.com/googleapis/langchain-google-spanner-python/issues/234

Summary of Changes
1. Python Version Updates (Commit 1)
Deprecated Python 3.9: Upgraded the minimum required Python version to 3.10 in pyproject.toml.
Added Python 3.13 Support: Added Python 3.13 to classifiers in pyproject.toml and updated the linter check workflow (lint.yml) to use Python 3.13.
Updated Ranges: Updated Python ranges in README.rst, DEVELOPER.md, and integration.cloudbuild.yaml to 3.10-3.13.
Updated Required Status Checks: Updated .github/sync-repo-settings.yaml to remove py39 and add py313 to the list of required status checks on GitHub.
Updated Docs Build Environment: Updated .kokoro/docker/docs/Dockerfile to install Python 3.10.19 instead of 3.9.13.
2. LangChain Dependency Updates (Commit 2)
Upgraded langchain-core: Updated requirement to >=1.0.0, <2.0.0.
Upgraded Companion Packages: Updated langchain and langchain-openai to >=1.0.0, <2.0.0 to maintain compatibility.
Added langchain-classic: Added langchain-classic dependency to support the legacy Chain class used by SpannerGraphQAChain.
Upgraded Test Dependency: Upgraded langchain_google_vertexai to >=3.0.0, <4.0.0 in test extras to resolve compatibility issues with langchain-core 1.x.
Fixed Imports:
Updated graph_qa.py and tests/integration/test_spanner_graph_qa.py to import Chain/load_evaluator from langchain_classic.
Updated graph_retriever.py to import BaseRetriever from langchain_core.retrievers.
