### PR TITLE
chore: add admin access for the spanner team

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -42,4 +42,4 @@ permissionRules:
   - team: senseai-eco
     permission: admin
   - team: langchain-spanner 
-    permission: push
+    permission: admin


### PR DESCRIPTION
https://github.com/googleapis/langchain-google-spanner-python/issues/234

Need to restart branch protection rule as prep work to check PR in.