### PR TITLE
fix: run lint check on python 3.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Install requirements
         run: pip install -r requirements.txt


### PR DESCRIPTION
This is a non-empty commit to trigger the release-please-bot with Release-As: v0.10.0. It reverts the lint workflow python version back to 3.11.